### PR TITLE
download-sdcnode should switch to /Joyent_Dev/public/releng/sdcnode

### DIFF
--- a/tools/download-sdcnode
+++ b/tools/download-sdcnode
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-BASEURL='https://download.joyent.com/pub/build/sdcnode'
+BASEURL='https://us-east.manta.joyent.com'
+MANTA_PATH='/Joyent_Dev/public/releng/sdcnode'
 BRANCH='master'
 IMAGE=$1
 VARIANT=$2
@@ -11,14 +12,32 @@ if [[ -z $IMAGE || -z $VARIANT || -z $OUTDIR ]]; then
 	exit 1
 fi
 
-FULLURL="$BASEURL/$IMAGE/$BRANCH-latest/sdcnode/"
+HAS_JSON=$(command -v json)
+if [[ -z "$HAS_JSON" ]]; then
+	printf 'ERROR: "json" command not found in $PATH'
+	exit 1
+fi
+
+FULLURL="$BASEURL/$MANTA_PATH/$IMAGE/$BRANCH-latest"
 TARGET="sdcnode-$VARIANT-$IMAGE.tar.gz"
 
 #
-# Download the index page which lists the current set of available sdcnode
-# builds:
+# We assume $FULLURL points to a Manta object that contains a path to
+# the actual branch Manta directory.
 #
-if ! list=$(curl -sSfL "$FULLURL") || [[ -z "$list" ]]; then
+if ! manta_path=$(curl -sSfL "$FULLURL") || [[ -z "$manta_path" ]]; then
+	printf "ERROR: could not determine manta_path url for $FULLURL\n" >&2
+	exit 1
+else
+	FULLURL="$BASEURL/$manta_path/sdcnode"
+fi
+
+#
+# Now download the Manta directory index which lists the current set of
+# available sdcnode builds. Note that this is assumed to be an
+# application/x-json-stream with one json record per line.
+#
+if ! list=$(curl -sSfL "$FULLURL" | json -ag name) || [[ -z "$list" ]]; then
 	printf 'ERROR: could not download index page\n' >&2
 	exit 1
 fi
@@ -31,7 +50,7 @@ fi
 #
 if ! name=$(awk -v "v=$VARIANT" -v "b=$BRANCH" -v "i=$IMAGE" -F\" '
     BEGIN { pattern = "^sdcnode-"v"-"i"-"b"-.*.tgz$"; }
-    $1 == "<a href=" && $2 ~ pattern { print $2 }' <<< "$list") ||
+    $1 ~ pattern { print $1 }' <<< "$list") ||
     [[ -z "$name" ]]; then
 	printf 'ERROR: could not locate file name in index page\n' >&2
 	exit 1
@@ -43,7 +62,7 @@ if [[ ! -f $OUTDIR/$name ]]; then
 	# download it now to a temporary file.  If it succeeds, move it into
 	# place.
 	#
-	if ! curl -sSf -o "$OUTDIR/.tmp.$name" "$FULLURL$name"; then
+	if ! curl -sSf -o "$OUTDIR/.tmp.$name" "$FULLURL/$name"; then
 		printf 'ERROR: could not download sdcnode' >&2
 		rm -f "$OUTPUT.tmp"
 		exit 1


### PR DESCRIPTION
I tested this by running the script, verifying that it was actually using https://us-east.manta.joyent.dev, as per TOOLS-2247

```
timf@jenkins-agent-x86_64-18.4.0 (move-off-download.j.c) mkdir ook
timf@jenkins-agent-x86_64-18.4.0 (move-off-download.j.c) ./download-sdcnode c2c31b00-1d60-11e9-9a77-ff9f06554b0f v6.17.0-zone64 ook
timf@jenkins-agent-x86_64-18.4.0 (move-off-download.j.c) ls -lar ook
total 16718
    1 lrwxrwxrwx 1 timf staff       96 Aug  8 14:13 sdcnode-v6.17.0-zone64-c2c31b00-1d60-11e9-9a77-ff9f06554b0f.tar.gz -> sdcnode-v6.17.0-zone64-c2c31b00-1d60-11e9-9a77-ff9f06554b0f-master-20190322T134555Z-g265fc63.tgz
16669 -rw-r--r-- 1 timf staff 17092278 Aug  8 14:13 sdcnode-v6.17.0-zone64-c2c31b00-1d60-11e9-9a77-ff9f06554b0f-master-20190322T134555Z-g265fc63.tgz
   25 drwxr-xr-x 3 timf staff        6 Aug  8 14:12 ../
   25 drwxr-xr-x 2 timf staff        4 Aug  8 14:13 ./
timf@jenkins-agent-x86_64-18.4.0 (move-off-download.j.c)
```